### PR TITLE
Easier to copy-and-paste renderman build instructions

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -65,8 +65,12 @@ download and install the python 3 version.
 
 	f) Update Xcode exporter
 
-		For the Xcode (MacOSX) exporter modify the *Extra Linker Flags*: remove ``-lpython3.6m``
-		Change ``-lboost-python`` to ``-lboost-python37`` and add ``-undefined dynamic_lookup``
+		For the Xcode (MacOSX) exporter check the *Extra
+		Linker Flags*. If it contains ``-lboost-python27``,
+		you have opened the wrong `.jucer` file. If it
+		contain ``-lboost-python37``, overwrite the *Extra
+		Linker Flags* with the following: ``-shared
+		-lboost_python -undefined dynamic_lookup``.
 
 		.. image:: images/linker_flags.png
 


### PR DESCRIPTION
In working through your RenderMan builds instructions---which are VERY helpful, by the way, thank you for the screenshots---one issue that came up was that I just wanted to copy and paste this variable block. It is updated.

I also wanted to update the following installation step, also, but I don't find it it github:

_VST Search Path

    If the VST (Legacy) SDK Folder under the main Xcode exporter tab isn’t filled, you will need to update that. Add the VST3_SDK folder here which is located in the RenderMan root directory._

My fixes would be

1. Move it into the 'Update Xcode exporter' step.
2. Rewrite it as:

If the VST (Legacy) SDK Folder under the main Xcode exporter tab isn’t filled, use: `<path-to-RenderMan>/VST3_SDK/`

